### PR TITLE
Fix #1: "atomically" read /proc files

### DIFF
--- a/mmapbench.cpp
+++ b/mmapbench.cpp
@@ -1,3 +1,4 @@
+// vim: set tabstop=2 softtabstop=2 shiftwidth=2:
 // sudo apt install libtbb-dev
 // g++ -O3 -g mmapbench.cpp -o mmapbench -ltbb -pthread
 
@@ -5,14 +6,18 @@
 #include <boost/algorithm/string.hpp>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <linux/fs.h>
 #include <random>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -23,11 +28,77 @@
 #include <thread>
 #include <unistd.h>
 #include <vector>
+
 #include "tbb/enumerable_thread_specific.h"
 
 using namespace std;
 
 #define check(expr) if (!(expr)) { perror(#expr); throw; }
+
+
+template<typename... Msgs>
+void handle_errno(int errsv, Msgs... msgs) {
+  if (errsv)
+    (std::cerr << ... << msgs) << ": " << std::strerror(errsv) << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+struct ProcFile
+{
+  friend void swap(ProcFile &first, ProcFile &second) {
+    using std::swap;
+    swap(first.path_,    second.path_);
+    swap(first.fd_,      second.fd_);
+    swap(first.buf_,     second.buf_);
+    swap(first.bufsize_, second.bufsize_);
+  }
+
+  private:
+  std::filesystem::path path_;
+  int fd_ = -1;
+  char *buf_ = nullptr;
+  std::size_t bufsize_;
+
+  public:
+  ProcFile() = default;
+  ProcFile(std::filesystem::path path, std::size_t buffer_size) : path_(std::move(path)), bufsize_(buffer_size) {
+    /*----- Open the file. -----*/
+    fd_ = open(path_.c_str(), O_RDONLY);
+    if (fd_ == -1)
+      handle_errno(errno, "Failed to open ", path_);
+
+    /*----- Allocate a *sufficiently large* buffer to fit in the file. -----*/
+    buf_ = new char[bufsize_];
+    // std::cerr << "Allocated buffer of " << bufsize_ << " bytes\n";
+  }
+
+  ProcFile(const ProcFile&) = delete;
+  ProcFile(ProcFile &&other) : ProcFile() { swap(*this, other); }
+
+  ProcFile & operator=(ProcFile &&other) { swap(*this, other); return *this; }
+
+  ~ProcFile() {
+    if (fd_ != -1) {
+      if (close(fd_))
+        handle_errno(errno, "Failed to close ", path_);
+    }
+    delete[] buf_;
+  }
+
+  std::string read() {
+    std::size_t bytes_read = 0;
+    do {
+      const auto n = pread(fd_, buf_ + bytes_read, bufsize_ - 1 - bytes_read, bytes_read); // may read less bytes
+      if (n == -1)
+        handle_errno(errno, "Failed to read ", path_);
+      if (n == 0) break; // no bytes read? then EOF
+      bytes_read += n;
+    } while (bytes_read != bufsize_); // remaining bytes to read?
+    buf_[bytes_read] = 0; // terminating NUL byte
+    return std::string(buf_);
+  }
+};
+
 
 double gettime() {
   struct timeval now_tv;
@@ -36,24 +107,31 @@ double gettime() {
 }
 
 uint64_t readTLBShootdownCount() {
-  std::ifstream irq_stats("/proc/interrupts");
-  assert (!!irq_stats);
+  static ProcFile interrupts("/proc/interrupts", 40'000);
+  std::string contents = interrupts.read();
 
-  for (std::string line; std::getline(irq_stats, line); ) {
-    if (line.find("TLB") != std::string::npos) {
-      std::vector<std::string> strs;
-      boost::split(strs, line, boost::is_any_of("\t "));
-      uint64_t count = 0;
-      for (size_t i = 0; i < strs.size(); i++) {
-	std::stringstream ss(strs[i]);
-	uint64_t c;
-	ss >> c;
-	count += c;
-      }
-      return count;
-    }
+  /*----- Extract TLB data. -----*/
+  const std::string::size_type pos = contents.find("TLB:");
+  if (pos == std::string::npos) [[unlikely]] {
+    return 0;
   }
-  return 0;
+  const std::string::size_type EOL = contents.find('\n', pos);
+  const std::string TLB_line = contents.substr(pos + 4, EOL);
+
+  /*----- Parse TLB shootdown counts. -----*/
+  int off = 0;
+  const char *cstr = TLB_line.c_str();
+  uint64_t count = 0;
+  for (;;) {
+    uint64_t tlb;
+    int n;
+    if (sscanf(cstr + off, "%lu %n", &tlb, &n) != 1)
+      break;
+    off += n;
+    count += tlb;
+  }
+
+  return count;
 }
 
 uint64_t readIObytesOne() {
@@ -72,22 +150,23 @@ uint64_t readIObytesOne() {
 }
 
 uint64_t readIObytes() {
-  std::ifstream stat("/proc/diskstats");
-  assert (!!stat);
+  static ProcFile diskstats("/proc/diskstats", 4000);
+  std::string contents = diskstats.read();
 
+  std::string::size_type pos = 0;
   uint64_t sum = 0;
-  for (std::string line; std::getline(stat, line); ) {
-    if (line.find("nvme") != std::string::npos) {
-      std::vector<std::string> strs;
-      boost::split(strs, line, boost::is_any_of("\t "), boost::token_compress_on);
-
-      std::stringstream ss(strs[6]);
-      uint64_t c;
-      ss >> c;
-      sum += c*512;
-    }
+  for (;;) {
+    pos = contents.find("nvme", pos); // next occurrence of "nvme"
+    if (pos == std::string::npos)
+      break;
+    const auto EOL = contents.find('\n', pos);
+    const std::string line = contents.substr(pos, EOL); // extract line with "nvme"
+    unsigned long num_sectors_read;
+    sscanf(line.c_str(), "%*s %*u %*u %lu", &num_sectors_read); // parse sectors read from extracted line
+    sum += num_sectors_read;
+    pos = EOL;
   }
-  return sum;
+  return sum * 512; // sectors to bytes
 }
 
 


### PR DESCRIPTION
This commit addresses the problem of reading files in `/proc` with a
buffered reader, e.g. `std::ifstream`.  With a buffered reader, a file
may be read in by multiple partial reads.  Between these partial reads,
the process may spend time on other work, e.g. parsing.  Within that
time frame, the file itself -- which is just a memory mapping of
kernel information -- may change.  A partial read *after* such a change
may cause spurious, non-repeatable readings and is basically a race
condition.

To circumvent this obstacle, this commit attempts to read the files in
`/proc` *atomically*, that is it performs a single read of the entire
file into a local buffer.  After reading of the entire file, that buffer
can be accessed and parsed (partially or entirely) without causing
races.

There is a notable issue with this attempt, though.  The kernel system
calls to read from a file, i.e. `read(2)` and `pread(2)`, are allowed to
read *less* bytes than requested.  This is *not* an error but it signals
to the calling process that successive reads are required.  The code
acknowledges this behavior and performs multiple successive reads of the
file, should it be necessary.  This means, in fact, that this is still
racy!  However, immediately querying reads for the entire file should
significantly reduce the time frame in which the file may change and
reduce the frequency of races.